### PR TITLE
make the task work on Ubuntu 16.10 with Ansible 2.2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     pkg={{ item }}
     state=latest
     update_cache=true
-  with_items: 'locale_language_packs'
+  with_items: "{{ locale_language_packs }}"
   register: 'locale_languages'
 
 - name: 'Reconfigure dpkg'


### PR DESCRIPTION
I couldn't get my playbook with this setup work:

    roles:
      - role: ssilab.locales
        locale: 'nb_NO'
        encoding: 'UTF-8'
        locales_user: "{{ ansible_ssh_user }}"
        locale_language_packs:
          - language-pack-nb
          - language-pack-nb-base
        tags:
          - language

So I cloned and changed as you can see, and now it works.